### PR TITLE
Add update() to window.onresize()

### DIFF
--- a/word-cloud.js
+++ b/word-cloud.js
@@ -25,9 +25,12 @@ var vis = svg.append("g").attr("transform", "translate(" + [w >> 1, h >> 1] + ")
 
 update();
 
-window.onresize = function(event) {
-    update();
-};
+if(window.attachEvent) {
+    window.attachEvent('onresize', update);
+}
+else if(window.addEventListener) {
+    window.addEventListener('resize', update);
+}
 
 function draw(data, bounds) {
     var w = window.innerWidth,


### PR DESCRIPTION
Added to onresize() event rather than replacing it. 

This found after an issue with us in SharePoint 2013 where increasing the size of the browser from what it was on pageload resulted in blank space.